### PR TITLE
Fix README to reflect project accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You'll need a Kubernetes cluster to run against. You can use [KIND](https://sigs
 
 - Kubernetes cluster (v1.27+)
 - JFrog instance with OIDC token exchange configured
+  - **Don't have a JFrog instance?** You can [provision a free trial of JFrog Artifactory](https://jfrog.com/start-free/) to test this controller
 - OIDC provider configured in JFrog that trusts your Kubernetes cluster's ServiceAccount tokens
 
 ### Configuration


### PR DESCRIPTION
Replace boilerplate Kubebuilder README with accurate documentation:
- Add clear project description and purpose
- Document how the token exchange flow works
- Add prerequisites and configuration requirements
- Remove incorrect CRD references (project uses ServiceAccounts)
- Add usage instructions with annotation example
- Reorganize sections for clarity