### PR TITLE
fix: handle optimistic concurrency conflicts on ServiceAccount updates

### DIFF
--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -201,6 +201,9 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Remove from imagePullSecrets if present (regardless of whether secret was found)
 		if err := r.removeImagePullSecret(ctx, &sa, secretName); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, fmt.Errorf("failed to remove imagePullSecret: %w", err)
 		}
 
@@ -286,6 +289,9 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Attach imagePullSecret to ServiceAccount if not already attached
 	if err := r.ensureImagePullSecret(ctx, &sa, secretName); err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to ensure image pull secret: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- `ensureImagePullSecret` and `removeImagePullSecret` were missing conflict handling on their `Update` calls
- Secret updates already handled `apierrors.IsConflict` with an immediate requeue (`ctrl.Result{Requeue: true}, nil`), but the equivalent ServiceAccount updates did not
- A concurrent write to the SA (e.g. from another controller or `kubectl`) would log an error and trigger exponential backoff instead of quietly retrying

## Test plan

- [ ] Verify existing controller tests pass (`make test`)
- [ ] Confirm no new errors appear in controller logs during normal reconciliation
- [ ] Optionally: trigger a concurrent SA update during reconciliation and confirm it requeues cleanly instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)