### PR TITLE
chore: inline release workflow and use a PAT instead of a GitHub App

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,8 +20,198 @@ permissions:
 
 jobs:
   release:
-    uses: richardmsong/shared-workflows/.github/workflows/tag-release.yml@7e4d37d1bab79696038882e240642177f34379ca # ratchet:richardmsong/shared-workflows/.github/workflows/tag-release.yml@main
-    with:
-      version: ${{ inputs.version || '' }}
-      dry-run: ${{ inputs.dry-run || false }}
-    secrets: inherit
+    name: Release
+    runs-on: ubuntu-latest
+    # Skip if triggered by github-actions bot to prevent loops
+    if: github.actor != 'github-actions[bot]'
+    env:
+      DRY_RUN: ${{ inputs.dry-run || false }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            echo "Error: Version not provided and not triggered by release event"
+            exit 1
+          fi
+          VERSION="${VERSION#v}"
+
+          # Validate version format
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format '$VERSION'. Expected format: X.Y.Z"
+            exit 1
+          fi
+
+          TAG="v${VERSION}"
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "major=${MAJOR}" >> $GITHUB_OUTPUT
+          echo "minor=${MINOR}" >> $GITHUB_OUTPUT
+          echo "patch=${PATCH}" >> $GITHUB_OUTPUT
+          echo "major_branch=v${MAJOR}" >> $GITHUB_OUTPUT
+          echo "minor_branch=v${MAJOR}.${MINOR}" >> $GITHUB_OUTPUT
+
+          echo "Version: ${VERSION}"
+          echo "Tag: ${TAG}"
+          echo "Major: ${MAJOR}, Minor: ${MINOR}, Patch: ${PATCH}"
+
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "::notice::DRY RUN MODE - No changes will be pushed"
+          fi
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Kustomize
+        run: |
+          if [ -f Makefile ] && grep -q "^kustomize:" Makefile; then
+            make kustomize
+          else
+            # Fallback to direct install
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+            mkdir -p bin
+            mv kustomize bin/
+          fi
+
+      - name: Update kustomization.yaml with version tag
+        id: update_kustomization
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          KUSTOMIZATION_PATH="config/manager"
+
+          cd "${KUSTOMIZATION_PATH}"
+
+          # Read existing image name from kustomization.yaml
+          EXISTING_IMAGE=$(grep -A2 "name: controller" kustomization.yaml | grep "newName:" | awk '{print $2}')
+
+          if [[ -z "$EXISTING_IMAGE" ]]; then
+            echo "Error: Could not find existing image name in kustomization.yaml"
+            echo "Make sure kustomization.yaml has an images entry with 'name: controller' and 'newName: <image>'"
+            exit 1
+          fi
+
+          echo "Found existing image: ${EXISTING_IMAGE}"
+
+          # Update only the tag using kustomize
+          ../../bin/kustomize edit set image controller=${EXISTING_IMAGE}:${VERSION}
+
+          echo "Updated kustomization.yaml:"
+          cat kustomization.yaml
+
+          cd -
+
+          echo "docker_image=${EXISTING_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
+
+          # Check if there are actual changes
+          if git diff --quiet "${KUSTOMIZATION_PATH}/kustomization.yaml"; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo ""
+            echo "Changes to be committed:"
+            git diff "${KUSTOMIZATION_PATH}/kustomization.yaml"
+          fi
+
+      - name: Commit version update
+        if: ${{ steps.update_kustomization.outputs.has_changes == 'true' }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git add config/manager/kustomization.yaml
+          git commit -m "chore: update Docker image tag to ${TAG} [skip ci]"
+
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "::notice::DRY RUN - Would push commit to ${{ github.event.repository.default_branch }}"
+          else
+            git push origin ${{ github.event.repository.default_branch }}
+            echo "Committed version update to ${{ github.event.repository.default_branch }}"
+          fi
+
+      - name: Update tag to include version commit
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Delete local tag if it exists (from fetch)
+          git tag -d "$TAG" 2>/dev/null || true
+
+          # Create tag pointing to current HEAD (with updated kustomization.yaml)
+          git tag "$TAG"
+
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "::notice::DRY RUN - Would force push tag $TAG to $(git rev-parse HEAD)"
+          else
+            git push origin "$TAG" --force
+            echo "Tag $TAG now points to commit with updated kustomization.yaml"
+          fi
+
+      - name: Create or update minor version branch
+        run: |
+          MINOR_BRANCH="${{ steps.version.outputs.minor_branch }}"
+          TAG="${{ steps.version.outputs.tag }}"
+
+          git branch -f "${MINOR_BRANCH}" HEAD
+
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "::notice::DRY RUN - Would force push branch $MINOR_BRANCH"
+          else
+            git push origin "${MINOR_BRANCH}" --force
+            echo "Minor branch ${MINOR_BRANCH} now points to ${TAG}"
+          fi
+
+      - name: Create or update major version branch
+        run: |
+          MAJOR_BRANCH="${{ steps.version.outputs.major_branch }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          MAJOR="${{ steps.version.outputs.major }}"
+
+          # Skip major branch for v0.x.x versions
+          if [[ "$MAJOR" == "0" ]]; then
+            echo "Skipping major branch creation for v0.x.x version"
+            exit 0
+          fi
+
+          git branch -f "${MAJOR_BRANCH}" HEAD
+
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "::notice::DRY RUN - Would force push branch $MAJOR_BRANCH"
+          else
+            git push origin "${MAJOR_BRANCH}" --force
+            echo "Major branch ${MAJOR_BRANCH} now points to ${TAG}"
+          fi
+
+      - name: Summary
+        run: |
+          if [[ "${{ env.DRY_RUN }}" == "true" ]]; then
+            echo "## Dry Run Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> No changes were pushed. This was a test run." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag**: ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${{ steps.update_kustomization.outputs.docker_image }}" ]]; then
+            echo "- **Docker Image**: \`${{ steps.update_kustomization.outputs.docker_image }}\`" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Branches" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ steps.version.outputs.minor_branch }}\` -> \`${{ steps.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.version.outputs.major }}" != "0" ]]; then
+            echo "- \`${{ steps.version.outputs.major_branch }}\` -> \`${{ steps.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- Inlines the Release job that used to come from richardmsong/shared-workflows/.github/workflows/tag-release.yml — this repo moved out of the richardmsong namespace into RBC, and that reusable workflow requires CLAUDE_APP_ID/CLAUDE_APP_PRIVATE_KEY secrets that don't exist under this org, so every release run has been failing (see run 30689255017).
- Drops the GitHub App token step (actions/create-github-app-token) and authenticates checkout/push/tag operations with a plain PAT (secrets.RELEASE_PAT) instead.
- Removes the now-unused workflow_call input toggles (update-kustomization, create-major-branch, create-minor-branch, kustomization-path) — this repo's caller never overrode them, so their defaults (config/manager, all enabled) are hardcoded in directly. No behavior change.

## Test plan
- [ ] Create a repo secret named RELEASE_PAT (classic PAT with repo scope, or fine-grained with Contents: Read & Write on this repo) before merging
- [ ] Trigger workflow_dispatch with dry-run: true and confirm the summary output looks right
- [ ] Publish a real release (or workflow_dispatch with dry-run: false) and confirm the tag, minor/major branches, and kustomization.yaml bump all land correctly