### PR TITLE
fix: use the default GITHUB_TOKEN for the release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary
- Swaps `secrets.RELEASE_PAT` for `secrets.GITHUB_TOKEN` in the release workflow (from #51) — no PAT secret needed after all.
- Checked: this repo has no branch protection on `main` or `v0.0`, and no repository rulesets, so nothing requires an elevated/external token to push commits, tags, or force-push branches.
- The workflow already declares `permissions: contents: write` at the top level, which is exactly the scope `GITHUB_TOKEN` needs for these operations.
- The one real limitation of `GITHUB_TOKEN` (its pushes don't trigger other workflow runs, to prevent accidental loops) doesn't bite here either: the version-bump commit already carries `[skip ci]`, and the tag + minor/major branches this job moves all point at that same commit, so none of those pushes would trigger `ci.yml` regardless of which token pushed them.

## Test plan
- [ ] Trigger `workflow_dispatch` with `dry-run: true` and confirm it runs end-to-end without needing any new secret
- [ ] Publish a real release (or `workflow_dispatch` with `dry-run: false`) and confirm the tag, minor/major branches, and `kustomization.yaml` bump all land correctly